### PR TITLE
[BUG] Fix issue 14 - script fail on strict due to indefined variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject

--- a/app/code/community/Aoe/TemplateHints/Helper/BlockInfo.php
+++ b/app/code/community/Aoe/TemplateHints/Helper/BlockInfo.php
@@ -115,13 +115,14 @@ class Aoe_TemplateHints_Helper_BlockInfo extends Mage_Core_Helper_Abstract {
 					}
 				} else {
 					$info[$currentClassName] = array('(skipping)');
+                                        break;
 				}
 
 				$level++;
 
 				$currentClass = $parentClass;
 				$currentClassName = $currentClass->getName();
-				$currentMethods = $parentMethods;
+                                $currentMethods = $parentMethods;
 				$parentClass = $currentClass->getParentClass();
 			}
 


### PR DESCRIPTION
In fact there is only a break missing causing the while loop to work on even if the target mage template classes are reached.
