### PR TITLE
Fix: #18 - More explicit tool tip styles

### DIFF
--- a/skin/frontend/base/default/aoe_templatehints/css/aoe_templatehints.css
+++ b/skin/frontend/base/default/aoe_templatehints/css/aoe_templatehints.css
@@ -12,7 +12,8 @@
 .implicitlycached:hover { box-shadow: 0 0 3px 3px orange; }
 
 .ot-container { width: 500px; }
-.opentip .header { margin: 0; padding: 0; position: inherit; text-align: left; width: auto; z-index: auto; }
+.opentip { color:black; font-family: sans-serif }
+.opentip .header { margin: 0; padding: 0; position: inherit; text-align: left; width: auto; z-index: auto; background: none; height: auto; }
 .opentip .content { text-align: left; }
 .opentip dt { font-weight: bold; }
 .opentip dd { margin-left: 20px; margin-bottom: 10px; word-wrap: break-word; }


### PR DESCRIPTION
The tool tip is using classes content and body which are often
have site-specific styles.

Some common values (background, font, color) are now reset.
