### PR TITLE
Change event observer name for easier debugging

### DIFF
--- a/app/code/community/Aoe/TemplateHints/etc/config.xml
+++ b/app/code/community/Aoe/TemplateHints/etc/config.xml
@@ -31,11 +31,11 @@
         <events>
             <core_block_abstract_to_html_after>
                 <observers>
-                    <core_block_abstract_to_html_after>
+                    <aoe_templatehints>
                         <type>singleton</type>
                         <class>Aoe_TemplateHints_Model_Observer</class>
                         <method>core_block_abstract_to_html_after</method>
-                    </core_block_abstract_to_html_after>
+                    </aoe_templatehints>
                 </observers>
             </core_block_abstract_to_html_after>
         </events>


### PR DESCRIPTION
The best practice is to use module name as an observer name (to avoid conflicts with other modules)