### PR TITLE
Add cms widget block support

### DIFF
--- a/app/code/community/Aoe/TemplateHints/Helper/BlockInfo.php
+++ b/app/code/community/Aoe/TemplateHints/Helper/BlockInfo.php
@@ -56,7 +56,7 @@ class Aoe_TemplateHints_Helper_BlockInfo extends Mage_Core_Helper_Abstract {
             $info['cms-pageId'] = $block->getPage()->getIdentifier();
         }
         if ($block instanceof Mage_Cms_Block_Widget_Block) {
-            $info['widget-blockId'] = $block->getData('block_id');
+            $info['widget-blockId'] = $block->getBlockId();
         }
         $templateFile = $block->getTemplateFile();
         if ($templateFile) {

--- a/app/code/community/Aoe/TemplateHints/Helper/BlockInfo.php
+++ b/app/code/community/Aoe/TemplateHints/Helper/BlockInfo.php
@@ -55,6 +55,9 @@ class Aoe_TemplateHints_Helper_BlockInfo extends Mage_Core_Helper_Abstract {
         if ($block instanceof Mage_Cms_Block_Page) {
             $info['cms-pageId'] = $block->getPage()->getIdentifier();
         }
+        if ($block instanceof Mage_Cms_Block_Widget_Block) {
+            $info['widget-blockId'] = $block->getData('block_id');
+        }
         $templateFile = $block->getTemplateFile();
         if ($templateFile) {
             $info['template'] = $templateFile;


### PR DESCRIPTION
Add `widget-blockId` to block info, so blocks used by widgets could be identified.
