### PR TITLE
Replace default settings for remote call

### DIFF
--- a/app/code/community/Aoe/TemplateHints/etc/config.xml
+++ b/app/code/community/Aoe/TemplateHints/etc/config.xml
@@ -47,7 +47,7 @@
             <aoe_templatehints>
                 <templateHintRenderer>aoe_templatehints/renderer_opentip</templateHintRenderer>
                 <enablePhpstormRemoteCall>0</enablePhpstormRemoteCall>
-                <remoteCallUrlTemplate><![CDATA[http://localhost:8091/?message=%s:%s]]></remoteCallUrlTemplate>
+                <remoteCallUrlTemplate><![CDATA[http://localhost:63342/api/file/%s:%s]]></remoteCallUrlTemplate>
             </aoe_templatehints>
         </dev>
     </default>

--- a/app/code/community/Aoe/TemplateHints/etc/system.xml
+++ b/app/code/community/Aoe/TemplateHints/etc/system.xml
@@ -30,7 +30,6 @@
                         </templateHintRenderer>
                         <enablePhpstormRemoteCall translate="label">
                             <label>Enable PHPStorm remote call</label>
-                            <comment><![CDATA[Install the "Remote Call" plugin in PHPStorm.]]></comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>200</sort_order>


### PR DESCRIPTION
Since https://github.com/zolotov/RemoteCall is not supported anymore and we could use IntelliJ REST API I replaced default value for remoteCallUrlTemplate


Further information:
https://github.com/zolotov/RemoteCall#not-supported-anymore
http://develar.org/idea-rest-api/#api-Platform-file